### PR TITLE
Add error when placing moment load and hinge at same location. Add in…

### DIFF
--- a/sympy/physics/continuum_mechanics/tests/test_beam.py
+++ b/sympy/physics/continuum_mechanics/tests/test_beam.py
@@ -520,9 +520,9 @@ def test_apply_hinge():
     b.apply_load(-10, 7, -1)
     b.apply_load(-2, 10, 0, 15)
     b.solve_for_reaction_loads(r0, m0, r10, r15)
-    R_0, M_0, R_10, R_15, P_7, P_12 = symbols('R_0, M_0, R_10, R_15, P_7, P_12')
+    R_0, M_0, R_10, R_15, EI_P_7, EI_P_12 = symbols('R_0, M_0, R_10, R_15, EI_P_7, EI_P_12')
     expected_reactions = {R_0: 20/3, M_0: -140/3, R_10: 31/3, R_15: 3}
-    expected_rotations = {P_7: 11405/27, P_12: -128425/324}
+    expected_rotations = {EI_P_7: 11405/27, EI_P_12: -128425/324}
     reaction_symbols = [r0, m0, r10, r15]
     rotation_symbols = [p7, p12]
     tolerance = 1e-6
@@ -589,6 +589,7 @@ def test_apply_hinge():
 
     E = Symbol('E')
     I = Symbol('I')
+    M = Symbol('M')
     b = Beam(10, E, I)
     b.apply_support(2, type="fixed")
     b.apply_support(10, type="pin")
@@ -601,6 +602,11 @@ def test_apply_hinge():
         b.apply_hinge(6)
     with raises(ValueError):
         b.apply_hinge(10)
+    with raises(ValueError):
+        b.apply_load(M, 6, -2)
+    b.apply_load(M, 4, -2)
+    with raises(ValueError):
+        b.apply_hinge(4)
 
 def test_max_shear_force():
     E = Symbol('E')


### PR DESCRIPTION
…fo that rotation jump is multiplied by EI.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
